### PR TITLE
Use internal default as fallback for global options

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -68,14 +68,16 @@ diffobj_set_def_opts <- function() options(.default.opts)
 
 #' Shorthand Function for Accessing diffobj Options
 #'
-#' \code{gdo(x)} is equivalent to \code{getOption(sprintf("diffobj.\%s", x))}.
+#' \code{gdo(x)} is equivalent to \code{getOption(sprintf("diffobj.\%s", x))},
+#' falling back to \pkg{diffobj}'s internal default value if the option is
+#' not set.
 #'
 #' @export
 #' @param x character(1L) name off \code{diffobj} option to retrieve, without
 #'   the \dQuote{diffobj.} prefix
 #' @examples
 #' gdo("format")
-
-gdo <- function(x) getOption(sprintf("diffobj.%s", x))
-
-
+gdo <- function(x) {
+  opt <- sprintf("diffobj.%s", x)
+  getOption(opt, .default.opts[[opt]])
+}


### PR DESCRIPTION
I ran into this issue in a situation where we're evaluating semi-trusted user input where we want to be careful that the user cannot change external settings. As a result, we're carefully scrubbing and restoring the state of global option after evaluating the user input. Unfortunately, this led me to an issue where `diffobj` (and also `fansi`) set global options on load that may later removed and break package functionality.

Here's a simple reprex. Run a function that attaches diffobj, but where options are protected.

``` r
old <- options()
waldo::compare(1:5, 3:7)
#> `old`: 1 2 3 4 5
#> `new`: 3 4 5 6 7
```

Yes, the options are protected a little aggressively, restoring unset options to their original state...

``` r
nulls <- setdiff(names(options()), names(old))
old[nulls] <- list(NULL)
options(old)
```

with the side-effect of removing the `diffobj.max.diffs` option...

```r
options()$max.diffs
#> NULL
```

breaking any subsequent call to `ses()`.

``` r
waldo::compare(1:5, 3:7)
#> Error in ses_prep(a = a, b = b, max.diffs = max.diffs, warn = warn): Argument `max.diffs` must be scalar integer.
```

(Something similar happens for `diffobj.warn`.)

The solution I'm proposing is to fall back to the internal diffobj default value in `gdo()`. I think this is reasonable since I think it doesn't change the intended behavior and it matches the expectations described in the documentation:

```r
#' @param warn TRUE (default) or FALSE whether to warn if we hit
#'   \code{max.diffs}.
```

I recognize I haven't completely though through all of the implications, if there are any broader problems please feel free to treat this PR as an issue report 😄 